### PR TITLE
Allow empty fields at the end of a name table

### DIFF
--- a/src/main/java/com/google/typography/font/sfntly/table/core/NameTable.java
+++ b/src/main/java/com/google/typography/font/sfntly/table/core/NameTable.java
@@ -649,6 +649,9 @@ public final class NameTable extends SubTableContainerTable implements Iterable<
   public byte[] nameAsBytes(int index) {
     int length = this.nameLength(index);
     byte[] b = new byte[length];
+    if (length <= 0) {
+        return b;
+    }
     this.data.readBytes(this.nameOffset(index), b, 0, length);
     return b;
   }


### PR DESCRIPTION
Allow empty fields in the name table. In particular, at the end of the name table. There is an error case where the last entry in the name table has length 0 so we have the following case:

NameTable length = 10
first entry: start 0, length 5
second entry: start 5, length 5
third entry: start 10, length 0

trying to read the thrid entry we start the read out of bounds.

This also matches the implementation in the cpp version (https://github.com/googlefonts/sfntly/blob/1e7adf313bd9c488a70015f8df8782f7c65e9ce7/cpp/src/sfntly/table/core/name_table.cc#L468)